### PR TITLE
Bundle `openff-nagl-models` with full package

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
         - python >=3.9
       run:
         - python >=3.9
-        - openff-nagl-models
+        - openff-nagl-models >= 0.1.0
         - dgl >=1.0
         - dask-jobqueue
         - {{ pin_subpackage('openff-nagl-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,10 @@ outputs:
     test:
       imports:
         - openff.nagl
+      files:
+        - test_models_loadable.py
+      commands:
+        - python test_models_loadable.py
 
 about:
   home: https://openforcefield.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 143282f824ad13854b0d8a9288746e6f60b96d026877f36058e58a29a9c593db
 
 build:
-  number: 0  
+  number: 1
 
 outputs:
   - name: openff-nagl-base
@@ -47,6 +47,7 @@ outputs:
         - python >=3.9
       run:
         - python >=3.9
+        - openff-nagl-models
         - dgl >=1.0
         - dask-jobqueue
         - {{ pin_subpackage('openff-nagl-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
         - python >=3.9
       run:
         - python >=3.9
-        - openff-nagl-models >= 0.1.0
+        - openff-nagl-models >=0.1.0
         - dgl >=1.0
         - dask-jobqueue
         - {{ pin_subpackage('openff-nagl-base', exact=True) }}

--- a/recipe/test_models_loadable.py
+++ b/recipe/test_models_loadable.py
@@ -1,6 +1,6 @@
 from openff.nagl import GNNModel
 from openff.nagl_models import list_available_nagl_models
 
-assert len(list_available_nagl_models) > 0
+assert len(list_available_nagl_models()) > 0
 
 [GNNModel.load(model) for model in list_available_nagl_models()]

--- a/recipe/test_models_loadable.py
+++ b/recipe/test_models_loadable.py
@@ -1,0 +1,6 @@
+from openff.nagl import GNNModel
+from openff.nagl_models import list_available_nagl_models
+
+assert len(list_available_nagl_models) > 0
+
+[GNNModel.load(model) for model in list_available_nagl_models()]


### PR DESCRIPTION
I'm lazy and would like to avoid continuing to need this in all of my environments:
```
  - openff-nagl
  - openff-nagl-models
```

* This structure implies to me that the default is to use NAGL without its associated models, which as a user seems backwards.
* If there is a use case of having NAGL but not bringing in its models, that's still enabled by pulling down `openff-nagl-base`.
* Finer control over version constraints between packages is still possible at the user level, short whatever constraints we might want to add in the recipe itself

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
