### PR TITLE
Drop `importlib.resources` backport

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c93ea4824aab37cff878b7ca9569677e72516f7ccd762a3eb557c80a9c8f9b46
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: openff-nagl-base
@@ -28,7 +28,6 @@ outputs:
         - python >={{ python_min }}
         - click
         - click-option-group
-        - importlib_resources
         - tqdm
         - openff-toolkit-base >=0.11.0
         - openff-units


### PR DESCRIPTION
This is no longer used in the codebase itself

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
